### PR TITLE
Allow CsvOutput inconsistent key update 

### DIFF
--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -39,7 +39,7 @@ class CsvOutput(FileOutput):
                 self._writer = csv.DictWriter(
                     self._log_file,
                     fieldnames=self._fieldnames,
-                    extrasaction='ignore')
+                    extrasaction='raise')
                 self._writer.writeheader()
 
             # add new keys to _fieldnames set
@@ -49,18 +49,7 @@ class CsvOutput(FileOutput):
 
             # if new keys are added, rewrite the csv file
             if len(self._fieldnames) > old_header_size:
-                self._writer = csv.DictWriter(
-                    self._log_file,
-                    fieldnames=sorted(list(self._fieldnames)),
-                    extrasaction='ignore')
-
-                self._log_file.seek(0)
-                self._writer.writeheader()
-
-                with open(self._file_name, 'r') as old_file:
-                    reader = csv.DictReader(old_file)
-                    for row in reader:
-                        self._writer.writerow(row)
+                self.update_header()
 
             self._writer.writerow(to_csv)
 
@@ -68,6 +57,21 @@ class CsvOutput(FileOutput):
                 data.mark(k)
         else:
             raise ValueError('Unacceptable type.')
+
+    # update self._writer and self._log_file with new self._fieldnames
+    def update_header(self):
+        self._writer = csv.DictWriter(
+            self._log_file,
+            fieldnames=sorted(list(self._fieldnames)),
+            extrasaction='raise')
+
+        self._log_file.seek(0)
+        self._writer.writeheader()
+
+        with open(self._file_name, 'r') as old_file:
+            reader = csv.DictReader(old_file)
+            for row in reader:
+                self._writer.writerow(row)
 
     def _warn(self, msg):
         """Warns the user using warnings.warn.

--- a/src/dowel/csv_output.py
+++ b/src/dowel/csv_output.py
@@ -1,8 +1,6 @@
 """A `dowel.logger.LogOutput` for CSV files."""
 import csv
 import warnings
-import os
-import tempfile
 
 from dowel import TabularInput
 from dowel.simple_outputs import FileOutput

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -102,7 +102,6 @@ class TestCsvOutput:
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 
-
     def test_empty_record(self):
         self.csv_output.record(self.tabular)
         assert not self.csv_output._writer

--- a/tests/dowel/test_csv_output.py
+++ b/tests/dowel/test_csv_output.py
@@ -35,16 +35,61 @@ class TestCsvOutput:
         ]  # yapf: disable
         self.assert_csv_matches(correct)
 
-    def test_record_inconsistent(self):
+    # Test if adding keys expands header and adds empty cells in previous rows
+    def test_record_inconsistent_add_keys_same_row_size(self):
         foo = 1
         bar = 10
         self.tabular.record('foo', foo)
         self.csv_output.record(self.tabular)
-        self.tabular.record('foo', foo * 2)
-        self.tabular.record('bar', bar * 2)
+        self.tabular.clear()
+        self.tabular.record('bar', bar)
+        self.csv_output.record(self.tabular)
 
-        with pytest.warns(CsvOutputWarning):
-            self.csv_output.record(self.tabular)
+        self.csv_output.dump()
+
+        correct = [
+            {'foo': str(foo), 'bar': ''},
+            {'foo': '', 'bar': str(bar)},
+        ]  # yapf: disable
+        self.assert_csv_matches(correct)
+
+    # Test if adding keys expands header and adds empty cells in previous rows
+    def test_record_inconsistent_add_keys_diff_row_size(self):
+        foo = 1
+        bar = 10
+        self.tabular.record('foo', foo)
+        self.csv_output.record(self.tabular)
+        self.tabular.clear()
+        self.tabular.record('bar', bar)
+        self.tabular.record('new1', 1)
+        self.csv_output.record(self.tabular)
+        self.tabular.clear()
+        self.tabular.record('bar', bar)
+        self.tabular.record('new1', 1)
+        self.tabular.record('new2', 2)
+        self.csv_output.record(self.tabular)
+        self.tabular.clear()
+
+        self.csv_output.dump()
+
+        correct = [
+            {'foo': str(foo), 'bar': '', 'new1': '', 'new2': ''},
+            {'foo': '', 'bar': str(bar), 'new1': '1', 'new2': ''},
+            {'foo': '', 'bar': str(bar), 'new1': '1', 'new2': '2'}
+        ]  # yapf: disable
+        self.assert_csv_matches(correct)
+
+    # Test if removing keys leaves empty cells in future rows
+    def test_record_inconsistent_remove_keys(self):
+        foo = 1
+        bar = 10
+        self.tabular.record('foo', foo)
+        self.tabular.record('bar', bar)
+        self.tabular.record('to_remove', foo)
+        self.csv_output.record(self.tabular)
+        self.tabular.clear()
+        self.tabular.record('bar', bar)
+        self.tabular.record('foo', foo * 2)
 
         # this should not produce a warning, because we only warn once
         self.csv_output.record(self.tabular)
@@ -52,10 +97,11 @@ class TestCsvOutput:
         self.csv_output.dump()
 
         correct = [
-            {'foo': str(foo)},
-            {'foo': str(foo * 2)},
+            {'foo': str(foo), 'bar': str(bar), 'to_remove': str(foo)},
+            {'foo': str(foo * 2), 'bar': str(bar), 'to_remove': ''},
         ]  # yapf: disable
         self.assert_csv_matches(correct)
+
 
     def test_empty_record(self):
         self.csv_output.record(self.tabular)


### PR DESCRIPTION
Add support for CsvOutput to handle dynamic keys by rewriting the log output csv file when new keys are detected. Although rewriting the file is slow, it works better for a large data stream case as the memory may not be able to hold large data. For a small data stream case, it will be more efficient to store the updated data in memory, and only update/rewrite the csv file when dump() is called. For this project I assume that data is large and choose the file rewrite option.

Warning is removed because now CsvOutput can handle inconsistent keys. Tests affected by this change are also fixed. 

